### PR TITLE
Use git tag for version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
+GIT_VERSION := $(shell git describe --abbrev=0 --tags)
+
 default: build
 
 test:
 	go test ./...
 
 build:
-	go build
+	go build -ldflags "-s -w -X github.com/thaim/tflint-ruleset-formatter/project.version=${GIT_VERSION}"
 
 install: build
 	mkdir -p ~/.tflint.d/plugins

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ test:
 	go test ./...
 
 build:
-	go build -ldflags "-s -w -X github.com/thaim/tflint-ruleset-formatter/project.version=${GIT_VERSION}"
+	go build -ldflags "-s -w -X main.version=${GIT_VERSION}"
 
 install: build
 	mkdir -p ~/.tflint.d/plugins

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/terraform-linters/tflint-plugin-sdk/plugin"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/thaim/tflint-ruleset-formatter/project"
 	"github.com/thaim/tflint-ruleset-formatter/rules"
 )
 
@@ -10,7 +11,7 @@ func main() {
 	plugin.Serve(&plugin.ServeOpts{
 		RuleSet: &tflint.BuiltinRuleSet{
 			Name:    "formatter",
-			Version: "0.1.0",
+			Version: project.GetVersion(),
 			Rules: []tflint.Rule{
 				rules.NewFormatterTrailingCommaRule(),
 				rules.NewFormatterMaxLenRule(),

--- a/main.go
+++ b/main.go
@@ -7,6 +7,16 @@ import (
 	"github.com/thaim/tflint-ruleset-formatter/rules"
 )
 
+var (
+	version = "main"
+	commit  = "none"
+	date    = "unknown"
+)
+
+func init() {
+	project.SetVersion(version)
+}
+
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
 		RuleSet: &tflint.BuiltinRuleSet{

--- a/project/main.go
+++ b/project/main.go
@@ -5,12 +5,18 @@ import (
 	"runtime/debug"
 )
 
+var version string
+
 // ReferenceLink returns the rule reference link
 func ReferenceLink(name string) string {
-	return fmt.Sprintf("https://github.com/thaim/tflint-ruleset-formatter/blob/%s/docs/rules/%s.md", getVersion(), name)
+	return fmt.Sprintf("https://github.com/thaim/tflint-ruleset-formatter/blob/%s/docs/rules/%s.md", GetVersion(), name)
 }
 
-func getVersion() string {
+func GetVersion() string {
+	if version != "" {
+		return version
+	}
+
 	i, ok := debug.ReadBuildInfo()
 	if !ok || i.Main.Version == "(devel)" {
 		return "main"

--- a/project/main.go
+++ b/project/main.go
@@ -12,6 +12,10 @@ func ReferenceLink(name string) string {
 	return fmt.Sprintf("https://github.com/thaim/tflint-ruleset-formatter/blob/%s/docs/rules/%s.md", GetVersion(), name)
 }
 
+func SetVersion(v string) {
+	version = v
+}
+
 func GetVersion() string {
 	if version != "" {
 		return version


### PR DESCRIPTION
Git tag is not used when build on both goreleaser and local Makefile. It always resolved as 'main'.

Use `main.version` regardless of the build method.
As a result, the generated document links will be determined based on the version.