### PR TITLE
Add rule to check for empty files

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ You can customize rule specific configurations. See [rule docs](docs/rules/) for
 |Rule|Description|Severity|Enabled by default|
 | --- | --- | --- | --- |
 |[formatter_blank_line](docs/rules/formatter_blank_line.md)|ensures that there are no extra blank lines|WARNING|✔
+|[formatter_empty_file](docs/rules/formatter_empty_file.md)|ensures that files are not empty|WARNING|✔
 |[formatter_eof](docs/rules/formatter_eof.md)|ensures that file end with new line|WARNING|✔
 |[formatter_max_len](docs/rules/formatter_max_len.md)|ensures the limitation of code line length|WARNING|✔
 |[formatter_trailing_comma](docs/rules/formatter_trailing_comma.md)|ensures that tuple element always end with comma|WARNING|✔

--- a/docs/rules/formatter_empty_file.md
+++ b/docs/rules/formatter_empty_file.md
@@ -1,0 +1,21 @@
+# formatter_empty_file
+
+This rule ensures there are no empty Terraform files.
+
+## Example
+
+```
+$ tflint
+
+1 issue(s) found:
+
+empty_file.tf:0:0: Warning - file has no content (formatter_empty_file)
+```
+
+## Why
+
+Having empty files in a project is confusing and gives unused maintenance and confusing, e.g. when browsing through folders.
+
+## How To Fix
+
+Remove the empty files from the project.

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ func main() {
 				rules.NewFormatterMaxLenRule(),
 				rules.NewFormatterEOFRule(),
 				rules.NewFormatterBlankLineRule(),
+				rules.NewFormatterEmptyFileRule(),
 			},
 		},
 	})

--- a/rules/formatter_empty_file.go
+++ b/rules/formatter_empty_file.go
@@ -1,0 +1,64 @@
+package rules
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/thaim/tflint-ruleset-formatter/project"
+)
+
+// FormatterEmptyFileRule checks if a Terraform file actually has any content
+type FormatterEmptyFileRule struct {
+	tflint.DefaultRule
+}
+
+func NewFormatterEmptyFileRule() *FormatterEmptyFileRule {
+	return &FormatterEmptyFileRule{}
+}
+
+func (r *FormatterEmptyFileRule) Name() string {
+	return "formatter_empty_file"
+}
+
+func (r *FormatterEmptyFileRule) Enabled() bool {
+	return true
+}
+
+func (r *FormatterEmptyFileRule) Severity() tflint.Severity {
+	return tflint.WARNING
+}
+
+func (r *FormatterEmptyFileRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+func (r *FormatterEmptyFileRule) Check(runner tflint.Runner) error {
+	files, err := runner.GetFiles()
+	if err != nil {
+		return err
+	}
+	for name, file := range files {
+		if err := r.checkEmpty(runner, name, file); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (r *FormatterEmptyFileRule) checkEmpty(runner tflint.Runner, filename string, file *hcl.File) error {
+	if len(file.Bytes) == 0 {
+		fileRange := hcl.Range{
+			Filename: filename,
+			Start:    hcl.Pos{Line: 0, Column: 0},
+			End:      hcl.Pos{Line: 0, Column: 0},
+		}
+
+		return runner.EmitIssue(
+			r,
+			"file has no content",
+			fileRange,
+		)
+	}
+
+	return nil
+}

--- a/rules/formatter_empty_file_test.go
+++ b/rules/formatter_empty_file_test.go
@@ -1,0 +1,44 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_FormatterEmptyFile(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name:    "file has no content",
+			Content: ``,
+			Expected: helper.Issues{
+				{
+					Rule:    NewFormatterEmptyFileRule(),
+					Message: "file has no content",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 0, Column: 0},
+						End:      hcl.Pos{Line: 0, Column: 0},
+					},
+				},
+			},
+		},
+	}
+
+	rule := NewFormatterEmptyFileRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/generator/main.go
+++ b/rules/generator/main.go
@@ -32,7 +32,8 @@ func main() {
 TODO:
 1. Remove all "TODO" comments from generated files.
 2. Write implementation of the rule.
-3. Add a link to the generated documentation into docs/rules/README.md`)
+3. Add the new rule to Rules in main.go
+4. Add a link to the generated documentation into docs/rules/README.md`)
 }
 
 func toCamel(ruleName string) string {


### PR DESCRIPTION
This PR adds a rule to check for empty files. Resolves https://github.com/thaim/tflint-ruleset-formatter/issues/31